### PR TITLE
Add parsing and test of nested arrays (objs with get_dict)

### DIFF
--- a/cwlgen/elements.py
+++ b/cwlgen/elements.py
@@ -189,5 +189,11 @@ class CommandInputArraySchema(object):
         :rtype: DICT
         '''
         dict_binding = {k: v for k, v in vars(self).items() if v is not None}
+
+        if hasattr(self.items, "get_dict"):
+            dict_binding["items"] = self.items.get_dict()
+        else:
+            dict_binding["items"] = str(self.items)
+
         return dict_binding
 

--- a/test/test_unit_typing.py
+++ b/test/test_unit_typing.py
@@ -60,3 +60,12 @@ class TestParamTyping(unittest.TestCase):
         self.assertIsInstance(ar, CommandInputArraySchema)
         self.assertEqual(parse_type(ar), ar)
         self.assertEqual(ar.items, "string?")
+
+    def test_array_of_array_of_strings(self):
+        arstr = CommandInputArraySchema(items="string")
+        ar = CommandInputArraySchema(items=arstr)
+        self.assertEqual(ar.get_dict(), {'type': 'array', 'items': {'type': 'array', 'items': 'string'}})
+
+    def test_parse_array_of_string_array(self):
+        ar = CommandInputArraySchema(items="string[]")
+        self.assertEqual(ar.get_dict(), {'type': 'array', 'items': {'type': 'array', 'items': 'string'}})


### PR DESCRIPTION
Add parsing and test of nested arrays (objs with get_dict)

Idea: generic to_dict where all objects inherit from some base "serialisable" that has some base get_dict method with:

```python
@staticmethod
def serialize(obj):
    if isinstance(v, str) or isinstance(v, int) or isinstance(v, float) or isinstance(v, bool):
        return v
    if isinstance(v, list):
        return [serialize(x) for x in v]
    if isinstance(v, dict):
        return {k: serialize(v) for k,v in v.items() if v is not None}
    if callable(getattr(v, "get_dict", None)):
        return v.get_dict()
    raise Exception(f"Can't serialize '{type(obj)}'")

def get_dict(self):
    return {k:serialize(v) for k,v in vars(self).items if v is not None)  
```